### PR TITLE
Add domain to subscription model

### DIFF
--- a/src/models/subscription.js
+++ b/src/models/subscription.js
@@ -5,9 +5,5 @@ export default {
     activate_time: '',
     expire_time: '',
     sort_number: null,
-    domain: {
-      jsonApi: 'hasOne',
-      type: 'domain',
-    },
   },
 };

--- a/src/models/subscription.js
+++ b/src/models/subscription.js
@@ -4,7 +4,10 @@ export default {
     name: '',
     activate_time: '',
     expire_time: '',
-    domain: '',
     sort_number: null,
+    domain: {
+      jsonApi: 'hasOne',
+      type: 'domain',
+    },
   },
 };


### PR DESCRIPTION
I reverted the changes from last month, because we never used them in the frontend. The frontend does not use the version 1.0.15 (which contains the changes that I reverted) and it works fine.
This https://www.npmjs.com/package/@joblocal/api-client-v5/v/1.0.14?activeTab=code is the version that is used in the frontend currently, so I want to go back to that.